### PR TITLE
feat: 검색 시 인원수 기준으로 리스트 출력 api

### DIFF
--- a/src/api/searchApi.ts
+++ b/src/api/searchApi.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient, useMutation } from '@tanstack/react-query';
 
 import { BASE_URL } from '@api/index';
 
@@ -8,7 +8,7 @@ const fetchHotels = async ({ queryKey }) => {
   const page = queryKey[1];
   try {
     const response = await axios.get(
-      `${BASE_URL}/hotels?_page=${page}_limit=10`,
+      `${BASE_URL}/hotels?_page=${page}&_limit=10`,
     );
     return response.data;
   } catch (error) {
@@ -35,4 +35,17 @@ const fetchHotelInformation = async ({ queryKey }) => {
 
 export const getHotelInformation = (hotelName: string) => {
   return useQuery(['hotel', 'detail', hotelName], fetchHotelInformation);
+};
+
+// 검색 시 max 기준으로 나열
+const fetchFilterHotels = ({ queryKey }) => {
+  const maxPerson = queryKey[2];
+  const response = axios.get(
+    `${BASE_URL}/hotels?occupancy.max_gte=${maxPerson}&_sort=occupancy.max`,
+  );
+  return response;
+};
+
+export const getFilterHotels = (max: number) => {
+  useQuery(['hotels', 'max', max], fetchFilterHotels);
 };


### PR DESCRIPTION
## 개요
- 검색 시 인원수 기준으로 호텔 리스트 출력
- fetchHotels의 오타 수정

## 변경 및 추가 로직
- `&` 가 빠져있던 것 추가
```javascript
  const response = await axios.get(
    `${BASE_URL}/hotels?_page=${page}&_limit=10`,
  );
```

## 사용 방법
- 호텔 검색

```javascript
// 최대 인원 수가 3명일 때
import {getFilterHotels} from '@api/searchApi';

const test1 = getFilterHotels(3);
console.log(test1.data);
```
