### PR TITLE
feat: calendarmodal 반응형적용 및 SearchDate 컴포넌트 calendar modal 추가

### DIFF
--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -2,13 +2,17 @@ import React, { useEffect, useRef } from 'react';
 import styled from 'styled-components';
 
 import { yearArray } from '@constants/day';
-import { disabledDate } from '@utils/disabledDate';
+import { Month } from '@components/calendar';
 import setDefaultDate from '@utils/setDefaultDate';
-import Month from '@components/calendar/Month';
+import disabledDate from '@utils/disabledDate';
 
-function Calendar() {
+interface ICalendarProps {
+  page: number;
+}
+
+function Calendar({ page }: ICalendarProps) {
   const checkRef = useRef<{ [key: string]: string }>({});
-  const dateRef = useRef<{ [key: string]: HTMLDivElement | null }>({});
+  const dateRef = useRef<{ [key: string]: HTMLDivElement }>({});
 
   const today = new Date();
   const year = today.getFullYear();
@@ -21,19 +25,41 @@ function Calendar() {
 
   return (
     <CalendarContainer>
-      {yearArray.map(index => (
-        <Month
-          key={index}
-          checkRef={checkRef}
-          dateRef={dateRef}
-          year={year}
-          month={month + index}
-        />
-      ))}
+      <MonthWrap>
+        {yearArray.map(index => (
+          <Month
+            key={index}
+            page={page}
+            checkRef={checkRef}
+            dateRef={dateRef}
+            year={year}
+            month={month + index}
+          />
+        ))}
+      </MonthWrap>
     </CalendarContainer>
   );
 }
 
 export default Calendar;
 
-const CalendarContainer = styled.div``;
+const CalendarContainer = styled.div`
+  text-align: center;
+  width: 100%;
+`;
+
+const MonthWrap = styled.div`
+  margin: 35px 50px 0;
+  width: 660px;
+  display: flex;
+  overflow: hidden;
+  @media ${({ theme }) => theme.deviceSize.middle} {
+    display: block;
+    width: 100%;
+    padding: 2vw;
+    margin: 17.5vw 0;
+  }
+  @media (min-width: 820px) {
+    height: 370px;
+  }
+`;

--- a/src/components/calendar/CalendarHeader.tsx
+++ b/src/components/calendar/CalendarHeader.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import styled from 'styled-components';
+import { MdClose } from 'react-icons/md';
+
+function CalendarHeader() {
+  return (
+    <MobileCalendarHeaderContainer>
+      <Title>일정 선택</Title>
+      <CloseButton>
+        <CloseIcon />
+      </CloseButton>
+    </MobileCalendarHeaderContainer>
+  );
+}
+
+export default CalendarHeader;
+
+const MobileCalendarHeaderContainer = styled.div`
+  display: none;
+  position: fixed;
+  z-index: 120;
+  width: 100%;
+  height: 17.5vw;
+  top: 0;
+  left: 0;
+  padding: 6vw 0px;
+  border-bottom: 1px solid #ccc;
+  background: #fff;
+  @media ${({ theme }) => theme.deviceSize.middle} {
+    display: block;
+  }
+`;
+const Title = styled.h2`
+  font-size: 5vw;
+  font-weight: 700;
+  text-align: center;
+`;
+const CloseButton = styled.button`
+  position: absolute;
+  right: 6vw;
+  top: 50%;
+  transform: translateY(-50%);
+  background: transparent;
+`;
+
+const CloseIcon = styled(MdClose)`
+  min-width: 20px;
+  min-height: 20px;
+  width: 6.5vw;
+  height: 6.5vw;
+`;

--- a/src/components/calendar/CalendarModal.tsx
+++ b/src/components/calendar/CalendarModal.tsx
@@ -1,0 +1,81 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+
+import {
+  Calendar,
+  CalendarHeader,
+  CalendarMoveButton,
+} from '@components/calendar';
+
+interface ICalendarModal {
+  display: boolean;
+}
+
+function CalendarModal({ display }: ICalendarModal) {
+  const startMonth = new Date().getMonth();
+  const [page, setPage] = useState<number>(startMonth);
+
+  return (
+    <CalendarModalContainer display={display}>
+      <CalendarHeader />
+      <CalendarMoveButton page={page} setPage={setPage} />
+      <Calendar page={page} />
+      <ButtonWrap>
+        <Button>적용</Button>
+      </ButtonWrap>
+    </CalendarModalContainer>
+  );
+}
+
+export default CalendarModal;
+
+const CalendarModalContainer = styled.div<{ display: boolean }>`
+  display: ${({ display }) => (display ? 'block' : 'none')};
+  position: absolute;
+  z-index: 100;
+  width: 760px;
+  height: 420px;
+  background: #fff;
+  box-shadow: 0px 5px 20px rgba(0, 0, 0, 0.25);
+  border-radius: 5px;
+  @media ${({ theme }) => theme.deviceSize.middle} {
+    width: 100%;
+    height: 100vh;
+    left: 0;
+    top: 0;
+    box-shadow: none;
+    border-radius: none;
+    padding: 0;
+    overflow-y: scroll;
+    scroll-behavior: smooth;
+    -ms-overflow-style: none;
+    ::-webkit-scrollbar {
+      display: none;
+    }
+  }
+`;
+
+const ButtonWrap = styled.div`
+  display: none;
+  position: fixed;
+  width: 100%;
+  height: 19vw;
+  bottom: 0;
+  left: 0;
+  padding: 4vw 6vw;
+  border-top: 1px solid #ccc;
+  background: #fff;
+  @media ${({ theme }) => theme.deviceSize.middle} {
+    display: block;
+  }
+`;
+
+const Button = styled.button`
+  width: 100%;
+  height: 11vw;
+  border-radius: 1vw;
+  font-size: 5vw;
+  font-weight: 700;
+  color: #fff;
+  background: ${({ theme }) => theme.color.pink_02};
+`;

--- a/src/components/calendar/CalendarMoveButton.tsx
+++ b/src/components/calendar/CalendarMoveButton.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import styled from 'styled-components';
+import { MdOutlineKeyboardArrowLeft } from 'react-icons/md';
+import { MdOutlineKeyboardArrowRight } from 'react-icons/md';
+
+interface CalendarMoveButtonProps {
+  page: number;
+  setPage: React.Dispatch<React.SetStateAction<number>>;
+}
+
+const CalendarMoveButton = ({ page, setPage }: CalendarMoveButtonProps) => {
+  const startMonth = new Date().getMonth();
+  const endMonth = startMonth + 12;
+
+  const handleMoveCalendar = (direction: number) => {
+    setPage(page => page + direction);
+  };
+
+  return (
+    <CalendarMoveButtonContainer>
+      <LeftButton
+        onClick={() => handleMoveCalendar(-1)}
+        disabled={page === startMonth}
+      >
+        <MdOutlineKeyboardArrowLeft />
+      </LeftButton>
+      <RightButton
+        onClick={() => handleMoveCalendar(1)}
+        disabled={page === endMonth - 1}
+      >
+        <MdOutlineKeyboardArrowRight />
+      </RightButton>
+    </CalendarMoveButtonContainer>
+  );
+};
+
+export default CalendarMoveButton;
+
+const CalendarMoveButtonContainer = styled.div`
+  position: absolute;
+  z-index: 110;
+  display: flex;
+  justify-content: space-between;
+  width: 630px;
+  top: 30px;
+  left: 65px;
+  svg {
+    width: 25px;
+    height: 25px;
+    color: ${({ theme }) => theme.color.grey_03};
+    cursor: pointer;
+  }
+`;
+
+const LeftButton = styled.button<{ disabled: boolean }>`
+  background: transparent;
+  svg {
+    color: ${({ disabled, theme }) => disabled && theme.color.grey_01};
+  }
+`;
+const RightButton = styled.button`
+  background: transparent;
+  svg {
+    color: ${({ disabled, theme }) => disabled && theme.color.grey_01};
+  }
+`;

--- a/src/components/calendar/Dates.tsx
+++ b/src/components/calendar/Dates.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import styled from 'styled-components';
 import { format } from 'date-fns';
+
 import { monthArray } from '@constants/day';
 
 interface IDatesProps {
   year: number;
   month: number;
   dateRef: React.MutableRefObject<{
-    [key: string]: HTMLDivElement | null;
+    [key: string]: HTMLDivElement;
   }>;
 }
 
@@ -26,7 +27,9 @@ function Dates({ year, month, dateRef }: IDatesProps) {
             key={day}
             start={start}
             dayOfWeek={dayOfWeek}
-            ref={ref => (dateRef.current[date] = ref)}
+            ref={ref => {
+              if (ref !== null) dateRef.current[date] = ref;
+            }}
           >
             <Day dayOfWeek={dayOfWeek}>{day}</Day>
           </DayWrap>
@@ -41,7 +44,10 @@ export default Dates;
 const DatesContainer = styled.div`
   display: grid;
   grid-template-columns: auto auto auto auto auto auto auto;
-  row-gap: 2.5vw;
+  row-gap: 15px;
+  @media ${({ theme }) => theme.deviceSize.middle} {
+    row-gap: 3.8vw;
+  }
 `;
 
 const DayWrap = styled.div<{ start: any; dayOfWeek: number }>`
@@ -102,11 +108,25 @@ const DayWrap = styled.div<{ start: any; dayOfWeek: number }>`
       color: #ccc;
     }
   }
+  &.today {
+    position: relative;
+    ::after {
+      content: '';
+      position: absolute;
+      bottom: 0;
+      left: 50%;
+      transform: translate(-50%);
+      width: 5px;
+      height: 5px;
+      border-radius: 50%;
+      background: ${({ theme }) => theme.color.pink_02};
+    }
+  }
 `;
 const Day = styled.button<{ dayOfWeek: number }>`
-  font-size: 2.5vw;
-  width: 5vw;
-  height: 5vw;
+  font-size: 16px;
+  width: 35px;
+  height: 35px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -116,4 +136,9 @@ const Day = styled.button<{ dayOfWeek: number }>`
     if (dayOfWeek === 0) return '#FF375C';
     return '#000';
   }};
+  @media ${({ theme }) => theme.deviceSize.middle} {
+    font-size: 4vw;
+    width: 10vw;
+    height: 10vw;
+  }
 `;

--- a/src/components/calendar/Month.tsx
+++ b/src/components/calendar/Month.tsx
@@ -2,21 +2,21 @@ import React from 'react';
 import styled from 'styled-components';
 import { format } from 'date-fns';
 
-import Week from '@components/calendar/Week';
-import Dates from '@components/calendar/Dates';
+import { Week, Dates } from '@components/calendar';
 
 interface IMonthProps {
   checkRef: React.MutableRefObject<{
     [key: string]: string;
   }>;
   dateRef: React.MutableRefObject<{
-    [key: string]: HTMLDivElement | null;
+    [key: string]: HTMLDivElement;
   }>;
   year: number;
   month: number;
+  page: number;
 }
 
-function Month({ checkRef, dateRef, year, month }: IMonthProps) {
+function Month({ checkRef, dateRef, year, month, page }: IMonthProps) {
   const monthTitle = format(new Date(year, month), 'yyyy.MM');
 
   const handleDate = (e: any) => {
@@ -60,7 +60,7 @@ function Month({ checkRef, dateRef, year, month }: IMonthProps) {
   };
 
   return (
-    <MonthContainer onClick={handleDate}>
+    <MonthContainer onClick={handleDate} page={page} month={month}>
       <Title>{monthTitle}</Title>
       <Week />
       <Dates year={year} month={month} dateRef={dateRef} />
@@ -70,11 +70,25 @@ function Month({ checkRef, dateRef, year, month }: IMonthProps) {
 
 export default Month;
 
-const MonthContainer = styled.div`
-  width: 60vw;
+const MonthContainer = styled.div<{ page: number; month: number }>`
+  margin-right: 30px;
+  @media ${({ theme }) => theme.deviceSize.middle} {
+    margin-right: 0;
+  }
+  @media (min-width: 820px) {
+    order: ${({ page, month }) => {
+      if (page === month) return 1;
+      if (page + 1 === month) return 2;
+      return 3;
+    }};
+  }
 `;
 const Title = styled.div`
-  margin: 4.5vw 0;
-  font-size: 2.5vw;
+  margin-bottom: 30px;
+  font-size: 17px;
   font-weight: 700;
+  @media ${({ theme }) => theme.deviceSize.middle} {
+    font-size: 4.5vw;
+    margin: 7vw 0 9.5vw;
+  }
 `;

--- a/src/components/calendar/Week.tsx
+++ b/src/components/calendar/Week.tsx
@@ -18,8 +18,17 @@ export default Week;
 const WeekContainer = styled.div`
   display: grid;
   grid-template-columns: auto auto auto auto auto auto auto;
-  height: 5vw;
+  color: ${({ theme }) => theme.color.grey_03};
+  height: 35px;
+  @media ${({ theme }) => theme.deviceSize.middle} {
+    height: 9.5vw;
+  }
 `;
 const DayOfWeek = styled.div`
-  font-size: 2vw;
+  font-size: 16px;
+  width: 45px;
+  margin: 0 auto;
+  @media ${({ theme }) => theme.deviceSize.middle} {
+    font-size: 4vw;
+  }
 `;

--- a/src/components/calendar/index.ts
+++ b/src/components/calendar/index.ts
@@ -2,3 +2,6 @@ export { default as Calendar } from './Calendar';
 export { default as Dates } from './Dates';
 export { default as Month } from './Month';
 export { default as Week } from './Week';
+export { default as CalendarMoveButton } from './CalendarMoveButton';
+export { default as CalendarHeader } from './CalendarHeader';
+export { default as CalendarModal } from './CalendarModal';

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -21,6 +21,9 @@ const LayoutContainer = styled.div`
   width: 900px;
   padding: 25px 30px;
   margin: 0 auto;
+  @media ${({ theme }) => theme.deviceSize.tablet} {
+    width: 100%;
+  }
 `;
 
 const Main = styled.main``;

--- a/src/components/search/SearchDate.tsx
+++ b/src/components/search/SearchDate.tsx
@@ -8,6 +8,7 @@ import IconWrapper from '@components/wrappers/IconWrapper';
 import BarWrapper from '@components/wrappers/BarWrapper';
 import KeyWordContainer from '@src/components/common/KeyWordContainer';
 import { IStyledProps } from '@type/style';
+import { CalendarModal } from '@components/calendar';
 
 function SearchDate() {
   const [display, setDisplay] = useState(false);
@@ -57,11 +58,7 @@ function SearchDate() {
         <KeyWordContainer content={`${diff}박`} />
         <KeyWordContainer color="grey_03" content="|" />
         <LabelInputWrapper width="36%" label="체크아웃" value={checkout} />
-        {display && (
-          <TempCalender height="64px" onClick={handleSubmit}>
-            캘린더 컴포넌트입니다.
-          </TempCalender>
-        )}
+        <CalendarModal display={display} />
       </BarWrapper>
     </SearchDateContainer>
   );

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,10 +1,12 @@
 const size = {
   mobile: '480px',
+  middle: '820px',
   tablet: '900px',
 };
 
 const deviceSize = {
   mobile: `(max-width : ${size.mobile})`,
+  middle: `(max-width : ${size.middle})`,
   tablet: `(max-width : ${size.tablet})`,
 };
 

--- a/src/utils/disabledDate.ts
+++ b/src/utils/disabledDate.ts
@@ -1,6 +1,6 @@
 import { format } from 'date-fns';
 
-export const disabledDate = (
+const disabledDate = (
   dateRef: React.MutableRefObject<{
     [key: string]: HTMLDivElement | null;
   }>,
@@ -16,3 +16,5 @@ export const disabledDate = (
     dateRef.current[String(i)]?.classList.add('disabled');
   }
 };
+
+export default disabledDate;


### PR DESCRIPTION
## 개요
resolved #21
- calendar modal 반응형적용
- seachbar에 추가

## 작업사항
- calendar modal을 생성해서 mobile과 web에 필요한 반응형 적용
- SearchDate 컴포넌트에 CalendarModal을 추가

## 변경 및 추가 로직
- SearchBar에 date부분을 클릭시 CalendarModal이 나타남
- Close구현은 아직 미완성

## 사용 방법
