### PR TITLE
refactor: react-query 로 무한스크롤 로직 변경

### DIFF
--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -1,9 +1,10 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import HotelCard from '@components/hotel/HotelCard';
 import styled from 'styled-components';
-import axios from 'axios';
 import useIntersection from '@hooks/useIntersection';
 import SearchBar from '@src/components/search/SearchBar';
+import { fetchHotels } from '@src/api/searchApi';
+import { useInfiniteQuery } from '@tanstack/react-query';
 
 const HomeImageSize = {
   desktop: { width: 220, height: 170 },
@@ -22,29 +23,23 @@ interface Hotel {
 }
 
 function Search() {
-  const [page, setPage] = useState(1);
-  const [data, setData] = useState<Hotel[] | []>([]);
-  const [isLoading, setIsLoading] = useState(false);
+  const { data, hasNextPage, fetchNextPage, isFetchingNextPage } =
+    useInfiniteQuery(['projects'], fetchHotels, {
+      getNextPageParam: (_, allPages) => {
+        if (allPages.length !== 101) {
+          return allPages.length;
+        }
+      },
+    });
 
   const onIntersect: IntersectionObserverCallback = ([{ isIntersecting }]) => {
     if (isIntersecting) {
-      setPage(prev => prev + 1);
-      setIsLoading(true);
+      if (!hasNextPage || !data) return;
+      fetchNextPage();
     }
   };
 
   const { setTarget } = useIntersection({ onIntersect });
-
-  useEffect(() => {
-    async function getData() {
-      const response = await axios.get(
-        `http://localhost:4000/hotels?_page=${page}`,
-      );
-      setData(prev => [...prev, ...response.data]);
-      setIsLoading(false);
-    }
-    getData();
-  }, [page]);
 
   return (
     <Container>
@@ -52,20 +47,26 @@ function Search() {
         <SearchBar />
       </SearchBarWrapper>
       <HotelCardWrapper>
-        {data &&
-          data.map((hotel: Hotel, key) => (
-            <HotelCard
-              key={key}
-              name={hotel.hotel_name}
-              base={hotel.occupancy.base}
-              max={hotel.occupancy.max}
-              price={'430,000원'}
-              imageSize={HomeImageSize}
-            />
-          ))}
-        {isLoading && <Loading>마지막 호텔입니다</Loading>}
+        {data?.pages &&
+          data.pages.map(page => {
+            return page.map((hotel: Hotel, key) => {
+              return (
+                <HotelCard
+                  key={key}
+                  name={hotel.hotel_name}
+                  base={hotel.occupancy.base}
+                  max={hotel.occupancy.max}
+                  price={'430,000원'}
+                  imageSize={HomeImageSize}
+                />
+              );
+            });
+          })}
       </HotelCardWrapper>
-      {data.length > 0 && <LastViewSection ref={setTarget} />}
+      {/* {<Loading>로딩중...</Loading>} */}
+      {data?.pages.length !== 0 && (
+        <LastViewSection ref={setTarget}>마지막 호텔입니다</LastViewSection>
+      )}
     </Container>
   );
 }
@@ -91,11 +92,19 @@ const HotelCardWrapper = styled.div`
 
 const LastViewSection = styled.div`
   padding: 100px;
-  height: 100px;
+  height: 50px;
+  border: 1px solid red;
+  color: #ff375c;
+  text-align: center;
 `;
 
 const Loading = styled.div`
-  color: #ff375c;
+  color: blue;
   text-align: center;
-  padding: 14px 0px;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 100;
 `;

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -88,6 +88,7 @@ const HotelCardWrapper = styled.div`
   margin: 0 auto;
   gap: 15px;
   height: 100%;
+  width: 612px;
 `;
 
 const LastViewSection = styled.div`

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -95,7 +95,7 @@ const LastViewSection = styled.div`
   padding: 100px;
   height: 50px;
   border: 1px solid red;
-  color: #ff375c;
+  color: ${({ theme }) => theme.color.lightRed};
   text-align: center;
 `;
 


### PR DESCRIPTION
## 개요
infinite-query 로 변경
## 작업사항
- search page 호텔카드 폭줄이기
- infinite-query 로 변경 
## 변경 및 추가 로직

## 사용 방법
```js
  const { data, hasNextPage, fetchNextPage, isFetchingNextPage } =
// fetchNextPage: 호출시 다음페이지로 넘깁니다
// isFetchingNextPage: fetch 상태를 boolean 으로 넘겨줍니다
// hasNextPage: 다음페이지가 있는지 없는지를 boolean 으로 넘겨줍니다 ( 밑의 getNextPageParam에서 적절한 값을 return 안해주면 undefined)
    useInfiniteQuery(['projects'], fetchHotels, {
      getNextPageParam: (_, allPages) => {   // 첫번째 param: 내가 가지고있는 맨마지막 페이지 데이터, 두번째 param: 가지고 있는 모든 데이터
        if (allPages.length !== 101) {   //맨 마지막 page면 x
          return allPages.length; // return 값은 다음페이지의 pageParams로 들어갈 값
          // 페이지의 기준을 총 데이터 길이로 정했습니다
        }
      },
    });
```
console.log(data)을 찍어보면 다음과 같이 page가 쌓입니다 
<img width="261" alt="스크린샷 2022-08-05 오후 12 46 54" src="https://user-images.githubusercontent.com/96074027/182997603-c42dcb3f-1462-49b9-b24d-eb89fadaa786.png">

