### PR TITLE
feat: 서치바에서 받은 모달의 값을 url에 쿼리스트링으로 전달

### DIFF
--- a/src/components/search/SearchBar.tsx
+++ b/src/components/search/SearchBar.tsx
@@ -1,14 +1,16 @@
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
+import { AiOutlineSearch } from 'react-icons/ai';
 
 import SearchDate from '@components/search/SearchDate';
 import SearchCount from '@components/search/SearchCount';
+import { CalendarModal } from '@components/calendar';
+import GuestReservation from '@components/modal/GuestReservation';
+import IconWrapper from '@wrappers/IconWrapper';
 import useWindowDimensions from '@hooks/useWindowDimensions';
 import useNavigateSearch from '@hooks/useNavigateSearch';
-import theme from '@styles/theme';
-import { CalendarModal } from '@components/calendar';
 import { ISearchData } from '@type/search';
-import GuestReservation from '../modal/GuestReservation';
+import theme from '@styles/theme';
 
 function SearchBar() {
   const { width } = useWindowDimensions();
@@ -42,20 +44,19 @@ function SearchBar() {
     }
   };
 
+  const handleSearch = () => {
+    const { checkIn, checkOut } = searchData.calendar;
+    const { adult, kid } = searchData.occupancy;
+    if (!adult && !kid) return navigateSearch('/', { checkIn, checkOut });
+    if (!checkIn || !checkOut) return navigateSearch('/', { adult, kid });
+    navigateSearch('/', { checkIn, checkOut, adult, kid });
+  };
+
   useEffect(() => {
     if (width <= +theme.size.middle.slice(0, -2)) {
       setIsWebWidth(false);
     } else setIsWebWidth(true);
   }, [width]);
-
-  useEffect(() => {
-    navigateSearch('/', {
-      checkIn: searchData.calendar.checkIn,
-      checkOut: searchData.calendar.checkOut,
-      adult: searchData.occupancy.adult,
-      kid: searchData.occupancy.kid,
-    });
-  }, [searchData]);
 
   return (
     <SearchBarContainer>
@@ -81,6 +82,11 @@ function SearchBar() {
         searchData={searchData}
         setSearchData={setSearchData}
       />
+      {isWebWidth && (
+        <SearchButtonWrapper onClick={handleSearch}>
+          <IconWrapper icon={<AiOutlineSearch />} color="pink_02" />
+        </SearchButtonWrapper>
+      )}
     </SearchBarContainer>
   );
 }
@@ -100,8 +106,12 @@ const SearchBarContainer = styled.div`
     border: none;
   }
   @media ${({ theme }) => theme.deviceSize.mobile} {
-    min-width: 300px; // temp
+    min-width: 300px;
     display: block;
     border: none;
   }
+`;
+
+const SearchButtonWrapper = styled.button`
+  background-color: transparent;
 `;

--- a/src/components/search/SearchBar.tsx
+++ b/src/components/search/SearchBar.tsx
@@ -100,7 +100,7 @@ const SearchBarContainer = styled.div`
   align-items: center;
   border: 1px solid ${({ theme }) => theme.color.grey_03};
   border-radius: 4px;
-  @media ${({ theme }) => theme.deviceSize.tablet} {
+  @media ${({ theme }) => theme.deviceSize.middle} {
     width: 100%;
     display: block;
     border: none;

--- a/src/components/search/SearchBar.tsx
+++ b/src/components/search/SearchBar.tsx
@@ -4,13 +4,15 @@ import styled from 'styled-components';
 import SearchDate from '@components/search/SearchDate';
 import SearchCount from '@components/search/SearchCount';
 import useWindowDimensions from '@hooks/useWindowDimensions';
+import useNavigateSearch from '@hooks/useNavigateSearch';
 import theme from '@styles/theme';
 import { CalendarModal } from '@components/calendar';
 import { ISearchData } from '@type/search';
 
 function SearchBar() {
   const { width } = useWindowDimensions();
-  const [isWebWidth, setIsWebWidth] = useState(true);
+  const navigateSearch = useNavigateSearch();
+  const [isWebWidth, setIsWebWidth] = useState<boolean>(true);
 
   const [isOpenModal, setIsOpenModal] = useState<{ [key: string]: boolean }>({
     calendar: false,
@@ -44,6 +46,15 @@ function SearchBar() {
       setIsWebWidth(false);
     } else setIsWebWidth(true);
   }, [width]);
+
+  useEffect(() => {
+    navigateSearch('/', {
+      checkIn: searchData.calendar.checkIn,
+      checkOut: searchData.calendar.checkOut,
+      adult: searchData.occupancy.adult,
+      kid: searchData.occupancy.kid,
+    });
+  }, [searchData]);
 
   return (
     <SearchBarContainer>

--- a/src/components/search/SearchCount.tsx
+++ b/src/components/search/SearchCount.tsx
@@ -28,7 +28,7 @@ const SearchCountContainer = styled.div`
   cursor: pointer;
   padding: 0 16px;
   width: 40%;
-  @media ${({ theme }) => theme.deviceSize.tablet} {
+  @media ${({ theme }) => theme.deviceSize.middlethe} {
     padding: 0 48px;
     width: 100%;
     border: 1px solid ${({ theme }) => theme.color.grey_03};

--- a/src/components/search/SearchCount.tsx
+++ b/src/components/search/SearchCount.tsx
@@ -1,14 +1,13 @@
-import React, { useState } from 'react';
+import React from 'react';
 import styled from 'styled-components';
-import { AiOutlineUser, AiOutlineSearch } from 'react-icons/ai';
+import { AiOutlineUser } from 'react-icons/ai';
 
 import IconWrapper from '@components/wrappers/IconWrapper';
 import BarWrapper from '@components/wrappers/BarWrapper';
-import KeyWordContainer from '@src/components/common/KeyWordContainer';
-import { IStyledProps } from '@type/style';
+import KeyWordContainer from '@components/common/KeyWordContainer';
 import { ISearchInnerProps } from '@type/search';
 
-function SearchCount({ isWeb, handleModal, searchData }: ISearchInnerProps) {
+function SearchCount({ handleModal, searchData }: ISearchInnerProps) {
   return (
     <SearchCountContainer onClick={() => handleModal('occupancy', true)}>
       <BarWrapper height="64px">
@@ -18,7 +17,6 @@ function SearchCount({ isWeb, handleModal, searchData }: ISearchInnerProps) {
         <KeyWordContainer content="|" color="grey_03" />
         <KeyWordContainer content="어린이 :" color="grey_03" />
         <KeyWordContainer content={`${searchData.occupancy.kid}명`} />
-        {isWeb && <IconWrapper icon={<AiOutlineSearch />} color="pink_02" />}
       </BarWrapper>
     </SearchCountContainer>
   );
@@ -39,14 +37,4 @@ const SearchCountContainer = styled.div`
   @media ${({ theme }) => theme.deviceSize.mobile} {
     padding: 0 12px;
   }
-`;
-
-const TempCounter = styled.div<IStyledProps>`
-  margin-top: 12px;
-  position: absolute;
-  top: ${props => props.height};
-  left: 0;
-  width: 200px;
-  height: 200px;
-  background-color: ${({ theme }) => theme.color.grey_01};
 `;

--- a/src/components/search/SearchDate.tsx
+++ b/src/components/search/SearchDate.tsx
@@ -54,7 +54,7 @@ const SearchDateContainer = styled.div`
   padding: 0 16px;
   width: 60%;
   border-right: 1px solid ${({ theme }) => theme.color.grey_03};
-  @media ${({ theme }) => theme.deviceSize.tablet} {
+  @media ${({ theme }) => theme.deviceSize.middle} {
     margin-bottom: 8px;
     padding: 0 48px;
     width: 100%;

--- a/src/components/wrappers/IconWrapper.tsx
+++ b/src/components/wrappers/IconWrapper.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 interface IIconWrapperProps {
   icon: JSX.Element;
   color?: string;
+  onClick?: (event: React.MouseEvent) => void;
 }
 
 function IconWrapper({ icon, color }: IIconWrapperProps) {

--- a/src/hooks/useNavigateSearch.ts
+++ b/src/hooks/useNavigateSearch.ts
@@ -1,0 +1,9 @@
+import { createSearchParams, useNavigate } from 'react-router-dom';
+
+function useNavigateSearch() {
+  const navigate = useNavigate();
+  return (pathname, params) =>
+    navigate({ pathname, search: `?${createSearchParams(params)}` });
+}
+
+export default useNavigateSearch;


### PR DESCRIPTION
## 개요
- #25 

## 작업사항
1. 받은 파라미터를 url로 전달할 때 일일이 쿼리스트링으로 작성하는 방법 외에 어떤 방법이 있는지 찾다가, createSearchParams 라는 메서드를 찾았습니다! [깔끔하게 훅으로 뺄 수 있는 예제](https://ultimatecourses.com/blog/navigate-to-url-query-strings-search-params-react-router)가 있어서 유사하게 useNavigateSearch 훅으로 빼서 사용해 봤습니다.
  ```javascript
  import { createSearchParams, useNavigate } from 'react-router-dom';
  
  function useNavigateSearch() {
    const navigate = useNavigate();
    return (pathname, params) =>
      navigate({ pathname, search: `?${createSearchParams(params)}` });
  }
  
  export default useNavigateSearch;
  ```
2. 검색함수: 반응형을 고려해서 연결해서 조건에 따라 url을 다르게 주도록 구현했습니다.
  ```javascript
    const handleSearch = () => {
      const { checkIn, checkOut } = searchData.calendar; // 상태값에서 가져오기
      const { adult, kid } = searchData.occupancy;

      // querystring 을 만드는 훅을 호출
      if (!adult && !kid) return navigateSearch('/', { checkIn, checkOut }); // 인원이 둘 다 0명이면 날짜만 전달
      if (!checkIn || !checkOut) return navigateSearch('/', { adult, kid }); // 날짜가 없으면 인원수만 전달
      navigateSearch('/', { checkIn, checkOut, adult, kid });
    };
  ```

## 변경 및 추가 로직
- SearchCount 페이지 하위에 있던 버튼을 SearchBar 컴포넌트로 이동했습니다.
- 버튼에 함수를 연결했습니다. 지금은 웹일때만 보이는 검색 버튼에만 함수가 연결되어 있어서 이제 반응형으로 펼쳐진 모달 내에 props로 함수를 내려줘서 연결할 예정입니다.
- 서치페이지에서 테스트해볼때 아래 코드처럼 시도해봤고 들어오는 것 확인완료했습니다!!
```javascript
const location = useLocation(); // 라우터 훅 호출
const query = new URLSearchParams(location.search);

// 사용할 부분에서
const adult = query.get('adult');
const kid = query.get('kid');
```
