### PR TITLE
fix : 무한스크롤 1페이지 두번 나오는 현상 수정

### DIFF
--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -26,15 +26,15 @@ function Search() {
   const { data, hasNextPage, fetchNextPage, isFetchingNextPage } =
     useInfiniteQuery(['projects'], fetchHotels, {
       getNextPageParam: (_, allPages) => {
-        if (allPages.length !== 101) {
-          return allPages.length;
+        if (allPages.length < 100) {
+          return allPages.length + 1;
         }
       },
     });
-
+  console.log(data);
   const onIntersect: IntersectionObserverCallback = ([{ isIntersecting }]) => {
     if (isIntersecting) {
-      if (!hasNextPage || !data) return;
+      if (!hasNextPage || !data || isFetchingNextPage) return;
       fetchNextPage();
     }
   };

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -31,7 +31,7 @@ function Search() {
         }
       },
     });
-  console.log(data);
+
   const onIntersect: IntersectionObserverCallback = ([{ isIntersecting }]) => {
     if (isIntersecting) {
       if (!hasNextPage || !data || isFetchingNextPage) return;

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -92,20 +92,7 @@ const HotelCardWrapper = styled.div`
 `;
 
 const LastViewSection = styled.div`
-  padding: 100px;
-  height: 50px;
-  border: 1px solid red;
+  padding: 50px 0px;
   color: ${({ theme }) => theme.color.lightRed};
   text-align: center;
-`;
-
-const Loading = styled.div`
-  color: blue;
-  text-align: center;
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  z-index: 100;
 `;


### PR DESCRIPTION
## 개요
무한스크롤 1페이지 두번나오는 현상 수정
## 변경 및 추가 로직
페이지 당 1 length => 페이지를 넘기려면 length+1
isFetchingNextPage (다음페이지를 가져오는중인지 : boolean) 를 추가해줘서 빠르게 중복호출 돼서 두페이지씩 가져오는 부분도 개선했습니다