### PR TITLE
fix: useLocation 훅으로 새로고침시 state의 기본값을 쿼리스트링 값으로 대체

### DIFF
--- a/src/components/search/SearchBar.tsx
+++ b/src/components/search/SearchBar.tsx
@@ -9,10 +9,12 @@ import GuestReservation from '@components/modal/GuestReservation';
 import IconWrapper from '@wrappers/IconWrapper';
 import useWindowDimensions from '@hooks/useWindowDimensions';
 import useNavigateSearch from '@hooks/useNavigateSearch';
+import useLocationString from '@hooks/useLocationString';
 import { ISearchData } from '@type/search';
 import theme from '@styles/theme';
 
 function SearchBar() {
+  const locationQuery = useLocationString();
   const { width } = useWindowDimensions();
   const navigateSearch = useNavigateSearch();
   const [isWebWidth, setIsWebWidth] = useState<boolean>(true);
@@ -23,13 +25,20 @@ function SearchBar() {
   });
 
   const [searchData, setSearchData] = useState<ISearchData>({
-    calendar: { checkIn: '', checkOut: '' },
-    occupancy: { adult: 0, kid: 0 },
+    calendar: {
+      checkIn: locationQuery.checkIn,
+      checkOut: locationQuery.checkOut,
+    },
+    occupancy: {
+      adult: locationQuery.adult ? +locationQuery.adult : 2,
+      kid: locationQuery.kid ? +locationQuery.kid : 0,
+    },
   });
 
   const handleModal = (key: string, value: boolean) => {
     if (isWebWidth) {
       if (key === 'focus') {
+        handleSearch();
         return setIsOpenModal(() => ({ calendar: false, occupancy: false }));
       }
       if (key === 'next')
@@ -70,6 +79,7 @@ function SearchBar() {
         handleModal={handleModal}
         searchData={searchData}
         setSearchData={setSearchData}
+        handleSearch={handleSearch}
       />
       <SearchCount
         isWeb={isWebWidth}
@@ -81,6 +91,7 @@ function SearchBar() {
         handleModal={handleModal}
         searchData={searchData}
         setSearchData={setSearchData}
+        handleSearch={handleSearch}
       />
       {isWebWidth && (
         <SearchButtonWrapper onClick={handleSearch}>
@@ -113,5 +124,6 @@ const SearchBarContainer = styled.div`
 `;
 
 const SearchButtonWrapper = styled.button`
+  padding: 20px;
   background-color: transparent;
 `;

--- a/src/components/search/SearchBar.tsx
+++ b/src/components/search/SearchBar.tsx
@@ -79,7 +79,6 @@ function SearchBar() {
         handleModal={handleModal}
         searchData={searchData}
         setSearchData={setSearchData}
-        handleSearch={handleSearch}
       />
       <SearchCount
         isWeb={isWebWidth}
@@ -91,7 +90,6 @@ function SearchBar() {
         handleModal={handleModal}
         searchData={searchData}
         setSearchData={setSearchData}
-        handleSearch={handleSearch}
       />
       {isWebWidth && (
         <SearchButtonWrapper onClick={handleSearch}>

--- a/src/hooks/useLocationString.ts
+++ b/src/hooks/useLocationString.ts
@@ -1,0 +1,16 @@
+import { useLocation } from 'react-router-dom';
+
+function useLocationString() {
+  const location = useLocation();
+  const { search } = location;
+  const query = new URLSearchParams(search);
+  const result = {
+    checkIn: query.get('checkIn') ?? '',
+    checkOut: query.get('checkOut') ?? '',
+    adult: query.get('adult') ?? 2,
+    kid: query.get('kid') ?? 0,
+  };
+  return result;
+}
+
+export default useLocationString;


### PR DESCRIPTION
## 개요
- useLocationString 훅 작성

## 작업사항
- 훅으로 쿼리스트링의 값을 가져와서 state의 기본값으로 사용
- 쿼리스트링이 비어있는 경우 기본값을 적용

## 변경 및 추가 로직

## 사용 방법
```javascript
  const locationQuery = useLocationString(); // 훅을 가져와서 사용
```
locationQuery 객체 내부 구성
```javascript
{
    checkIn: query.get('checkIn') ?? '',
    checkOut: query.get('checkOut') ?? '',
    adult: query.get('adult') ?? 2,
    kid: query.get('kid') ?? 0,
  }
```
